### PR TITLE
Version 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
-## [0.1.5] - 2024-01-30
+## [0.1.6] - 2024-01-15
+- Renamed `ActiveResource::Collection#refresh` to `#reload` to match Rails ORM naming convention.
+- Added a `ActiveResource::Collection.none` class method similar to Rails `ActiveRecord::QueryMethods.none`
+- Enhanced `ActiveResource::Collection#where` so that it returns `ActiveResource::Collection.none` if `resource_class` is missing.
+    - This is useful for when `where` clauses are chained on an empty `ActiveResource::Collection`
+
+## [0.1.5] - 2024-01-09
 - Added callbacks to cache:
     - Create/POST, refresh cache after successful POST request
     - Update/PUT, refresh cache after successful PUT request
     - Destroy/DELETE, invalidate cache after successful DELETE request
 - Fixed issue with generator for SQLCache strategy tables
+
 ## [0.1.4] - 2024-12-20
 - CI Improvements
     - Added annotations

--- a/active_cached_resource.gemspec
+++ b/active_cached_resource.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activemodel", ">= 6.0"
   spec.add_dependency "activesupport", ">= 6.0"
   spec.add_dependency "msgpack", "~> 1.7", ">= 1.7.5"
+  spec.add_dependency "ostruct", "~> 0.6.1"
 end

--- a/lib/active_cached_resource/version.rb
+++ b/lib/active_cached_resource/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveCachedResource
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/lib/activeresource/lib/active_resource/collection.rb
+++ b/lib/activeresource/lib/active_resource/collection.rb
@@ -21,6 +21,23 @@ module ActiveResource # :nodoc:
     attr_writer :prefix_options
     attr_reader :from
 
+    # Returns a frozen empty collection.
+    #
+    # @return [ActiveResource::Collection] an empty collection
+    def self.none
+      new([]).tap do |collection|
+        collection.instance_variable_set(:@requested, true)
+      end
+    end
+
+    # Creates a new ActiveResource::Collection instance.
+    #
+    # ==== Arguments
+    #
+    # +elements+ (Array<Object>) - An optional array of resources to be set as the collection elements.
+    #                              Defaults to an empty array.
+    # +from+ (String, Symbol) - The path to the collection resource or the symbol for the collection resource.
+
     # ActiveResource::Collection is a wrapper to handle parsing index responses that
     # do not directly map to Rails conventions.
     #
@@ -98,12 +115,12 @@ module ActiveResource # :nodoc:
       @prefix_options || {}
     end
 
-    # Refreshes the collection by re-fetching the resources from the API.
+    # Reload the collection by re-fetching the resources from the API.
     #
     # ==== Returns
     #
     # [Array<Object>] The collection of resources retrieved from the API.
-    def refresh
+    def reload
       @requested = false
       request_resources!
     end
@@ -182,6 +199,7 @@ module ActiveResource # :nodoc:
     #   # => PostCollection:xxx (filtered collection)
     def where(clauses = {})
       raise ArgumentError, "expected a clauses Hash, got #{clauses.inspect}" unless clauses.is_a? Hash
+      return self.class.none if resource_class.nil?
       new_clauses = query_params.merge(clauses)
       resource_class.where(new_clauses)
     end

--- a/lib/activeresource/test/abstract_unit.rb
+++ b/lib/activeresource/test/abstract_unit.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "dotenv/load"
-require "pry-byebug"
 require "rubygems" unless defined? Gem
 require "bundler/setup"
 

--- a/lib/activeresource/test/cases/collection_test.rb
+++ b/lib/activeresource/test/cases/collection_test.rb
@@ -28,6 +28,16 @@ class BasicCollectionTest < CollectionTest
   def respond_to_where
     assert @collection.respond_to?(:where)
   end
+
+  def test_where_without_resource_class
+    assert_equal @collection.where(foo: 'bar'), ActiveResource::Collection.none
+  end
+
+  def test_none
+    none = ActiveResource::Collection.none
+    assert_kind_of ActiveResource::Collection, none
+    assert_empty none
+  end
 end
 
 class PaginatedCollection < ActiveResource::Collection
@@ -174,7 +184,7 @@ class CollectionInheritanceTest < ActiveSupport::TestCase
     posts.to_a
     assert posts.requested?
     assert_equal 1, ActiveResource::HttpMock.requests.count { |r| r == expected_request }
-    posts.refresh
+    posts.reload
     assert_equal 2, ActiveResource::HttpMock.requests.count { |r| r == expected_request }
     assert posts.requested?
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 
 require "dotenv/load"
 require "msgpack"
-require "pry-byebug"
 
 require "simplecov"
 


### PR DESCRIPTION
## Summary
- Renamed `ActiveResource::Collection#refresh` to `#reload` to match Rails ORM naming convention.
- Added a `ActiveResource::Collection.none` class method similar to Rails `ActiveRecord::QueryMethods.none`
- Enhanced `ActiveResource::Collection#where` so that it returns `ActiveResource::Collection.none` if `resource_class` is missing.
    - This is useful for when `where` clauses are chained on an empty `ActiveResource::Collection`