### PR TITLE
Version0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## [0.2.0] - 2024-02-15
+## [0.1.9] - 2024-02-05
 - Fixed bug not allowing reloading collection cache
+- Change debug to info for cache hits
+
+## [0.1.8] - 2024-01-24
+- Fixed issue with `#clear_cache` method with Redis
 
 ## [0.1.7] - 2024-01-23
 - Improved `clear_cache` method for `active_support_cache` strategy to no longer use `delete_matched`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.2.0] - 2024-02-15
+- Fixed bug not allowing reloading collection cache
+
 ## [0.1.7] - 2024-01-23
 - Improved `clear_cache` method for `active_support_cache` strategy to no longer use `delete_matched`.
 - Introduced `.delete_from_cache` method to delete single cached resources.

--- a/lib/active_cached_resource/caching.rb
+++ b/lib/active_cached_resource/caching.rb
@@ -148,7 +148,7 @@ module ActiveCachedResource
       #
       # @return [void]
       def clear_cache
-        cached_resource.logger.debug("Clearing cache for #{name} cache with prefix: #{cache_key_prefix}")
+        cached_resource.logger.info("Clearing cache for #{name} cache with prefix: #{cache_key_prefix}")
         cached_resource.cache.clear(cache_key_prefix)
       end
 
@@ -166,7 +166,7 @@ module ActiveCachedResource
 
         return nil if json_string.nil?
 
-        cached_resource.logger.debug("[KEY:#{key}] Cache hit")
+        cached_resource.logger.info("[KEY:#{key}] Cache hit")
         json_to_object(json_string)
       end
 

--- a/lib/active_cached_resource/collection.rb
+++ b/lib/active_cached_resource/collection.rb
@@ -1,5 +1,15 @@
 module ActiveCachedResource
   class Collection < ActiveResource::Collection
+    # Reload the collection by re-fetching the resources from the API.
+    #
+    # ==== Returns
+    #
+    # [Array<Object>] The collection of resources retrieved from the API.
+    def reload
+      query_params[Constants::RELOAD_PARAM] = true
+      super
+    end
+
     private
 
     def request_resources!

--- a/lib/active_cached_resource/version.rb
+++ b/lib/active_cached_resource/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveCachedResource
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end


### PR DESCRIPTION
This pull request includes several changes to improve logging, fix bugs, and add new functionality to the `active_cached_resource` library. The most important changes include updating the logging level for cache operations, fixing a bug with reloading the collection cache, and adding a new `reload` method to the `Collection` class.

### Logging Improvements:
* Changed the logging level from `debug` to `info` for cache clearing operations in `lib/active_cached_resource/caching.rb`.
* Changed the logging level from `debug` to `info` for cache hit messages in `lib/active_cached_resource/caching.rb`.

### Bug Fixes:
* Fixed a bug that prevented reloading the collection cache by adding a new `reload` method to the `Collection` class in `lib/active_cached_resource/collection.rb`.

### New Features:
* Added a `reload` method to the `Collection` class to allow re-fetching resources from the API in `lib/active_cached_resource/collection.rb`.

### Documentation and Versioning:
* Updated the `CHANGELOG.md` to document the new version `0.1.9` and the changes included in this release.
* Updated the version number to `0.1.9` in `lib/active_cached_resource/version.rb`.

### Testing:
* Added helper methods and a test case for the new `reload` method in `spec/active_cached_resource/collection_spec.rb`.