### PR TITLE
Patch Collection#reload to return correct type

### DIFF
--- a/lib/activeresource/lib/active_resource/collection.rb
+++ b/lib/activeresource/lib/active_resource/collection.rb
@@ -122,7 +122,7 @@ module ActiveResource # :nodoc:
     # [Array<Object>] The collection of resources retrieved from the API.
     def reload
       @requested = false
-      request_resources!
+      call
     end
 
     # Executes the request to fetch the collection of resources from the API and returns the collection.

--- a/lib/activeresource/test/cases/collection_test.rb
+++ b/lib/activeresource/test/cases/collection_test.rb
@@ -184,7 +184,7 @@ class CollectionInheritanceTest < ActiveSupport::TestCase
     posts.to_a
     assert posts.requested?
     assert_equal 1, ActiveResource::HttpMock.requests.count { |r| r == expected_request }
-    posts.reload
+    assert_kind_of PaginatedCollection, posts.reload
     assert_equal 2, ActiveResource::HttpMock.requests.count { |r| r == expected_request }
     assert posts.requested?
   end


### PR DESCRIPTION
This pull request includes changes to the `lib/activeresource` library to improve the functionality and testing of resource collections. The most important changes include modifying the `reload` method in the `Collection` class and updating the corresponding test case to ensure the correct type is returned.

Improvements to `Collection` class:

* [`lib/activeresource/lib/active_resource/collection.rb`](diffhunk://#diff-1183aaa4c8a0d214703287c8e875a0211857f8acd3363a20d7d57663c8968c0eL125-R125): Modified the `reload` method to call the `call` method instead of `request_resources!`. This ensures it returns the correct object type.

Updates to test cases:

* [`lib/activeresource/test/cases/collection_test.rb`](diffhunk://#diff-ba121d0ed442ebc07bedee375aafee219ae3216566cd4790bf0267894faf41c5L187-R187): Updated the `test_refresh` method to assert that `reload` returns an instance of `PaginatedCollection`.Previously this returned only Array, it should return Collection type instead.