### PR TITLE
New feature allows caching of virtual attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.2.0] - 2024-04-25
+## [0.2.0] - 2024-04-24
 - Allow virtual attributes to be persisted into cache with introduction of `ActiveCachedResource::Collection.persisted_attribute`.
 - Optimized cache key generation by switching from `SHA-256` to `MD5`, improving hashing performance while maintaining uniqueness.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [0.2.0] - 2024-04-25
 - Allow virtual attributes to be persisted into cache with introduction of `ActiveCachedResource::Collection.persisted_attribute`.
+- Optimized cache key generation by switching from `SHA-256` to `MD5`, improving hashing performance while maintaining uniqueness.
 
 ## [0.1.10] - 2024-03-05
 - Patch Collection#reload to return correct type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.2.0] - 2024-04-25
+- Allow virtual attributes to be persisted into cache with introduction of `ActiveCachedResource::Collection.persisted_attribute`.
+
+## [0.1.10] - 2024-03-05
+- Patch Collection#reload to return correct type
+
 ## [0.1.9] - 2024-02-05
 - Fixed bug not allowing reloading collection cache
 - Change debug to info for cache hits

--- a/lib/active_cached_resource/caching_strategies/base.rb
+++ b/lib/active_cached_resource/caching_strategies/base.rb
@@ -120,7 +120,7 @@ module ActiveCachedResource
         if prefix.nil? || k.nil?
           raise ArgumentError, "Key must have a prefix and a key separated by a dash"
         end
-        "#{prefix}#{ActiveCachedResource::Constants::PREFIX_SEPARATOR}#{Digest::SHA256.hexdigest(k)}"
+        "#{prefix}#{ActiveCachedResource::Constants::PREFIX_SEPARATOR}#{Digest::MD5.hexdigest(k)}"
       end
 
       def compress(value)

--- a/lib/active_cached_resource/collection.rb
+++ b/lib/active_cached_resource/collection.rb
@@ -1,10 +1,27 @@
 module ActiveCachedResource
   class Collection < ActiveResource::Collection
+    class_attribute :virtual_persisted_attributes, default: []
+
+    # This method dynamically creates accessor methods for the specified attributes
+    # and adds them to a list of virtual persisted attributes to keep track of
+    # attributes that should be persisted to cache.
+    #
+    # @param args [Array<Symbol>] A list of attribute names to be persisted.
+    # @return [void]
+    def self.persisted_attribute(*args)
+      attr_accessor(*args)
+      self.virtual_persisted_attributes += args
+    end
+
+    def virtual_persistable_attributes
+      self.class.virtual_persisted_attributes.each_with_object({}) do |attribute, hash|
+        hash[attribute] = public_send(attribute)
+      end
+    end
+
     # Reload the collection by re-fetching the resources from the API.
     #
-    # ==== Returns
-    #
-    # [Array<Object>] The collection of resources retrieved from the API.
+    # @return Returns [Array<Object>] The collection of resources retrieved from the API.
     def reload
       query_params[Constants::RELOAD_PARAM] = true
       super
@@ -20,19 +37,34 @@ module ActiveCachedResource
       should_reload = query_params.delete(Constants::RELOAD_PARAM)
       if !should_reload
         from_cache = resource_class.send(:cache_read, from, path_params, query_params, prefix_options)
-        @elements = from_cache
-        return @elements if @elements
+        if from_cache
+          update_self!(from_cache)
+          return @elements if @elements
+        end
       end
 
       super # This sets @elements
 
       if resource_class.send(:should_cache?, @elements)
-        resource_class.send(:cache_write, @elements, from, path_params, query_params, prefix_options)
+        resource_class.send(:cache_write, self, from, path_params, query_params, prefix_options)
       end
 
       @elements
     ensure
       @requested = true
+    end
+
+    def update_self!(other_collection)
+      # Ensure that the virtual persisted attributes are also updated
+      self.class.virtual_persisted_attributes.each do |attribute|
+        public_send(:"#{attribute}=", other_collection.public_send(attribute))
+      end
+
+      @elements = other_collection.instance_variable_get(:@elements)
+      @from = other_collection.instance_variable_get(:@from)
+      @query_params = other_collection.query_params
+      @path_params = other_collection.path_params
+      @prefix_options = other_collection.prefix_options
     end
   end
 end

--- a/lib/active_cached_resource/version.rb
+++ b/lib/active_cached_resource/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveCachedResource
-  VERSION = "0.1.10"
+  VERSION = "0.2.0"
 end

--- a/lib/activeresource/lib/active_resource/collection.rb
+++ b/lib/activeresource/lib/active_resource/collection.rb
@@ -9,7 +9,7 @@ module ActiveResource # :nodoc:
     delegate :==, :[], :&, :*, :+, :-, :<=>, :all?, :any?, :as_json, :at, :assoc, :blank?, :bsearch, :bsearch_index,
          :collect, :combination, :compact, :count, :cycle, :deconstruct, :deep_dup, :dig, :difference, :drop,
          :drop_while, :each, :each_index, :empty?, :eql?, :excluding, :filter, :fifth, :find_index, :first,
-         :flatten, :forty_two, :fourth, :from, :hash, :include?, :including, :index, :inspect, :intersect?,
+         :flatten, :fourth, :hash, :include?, :including, :index, :inspect, :intersect?,
          :intersection, :join, :last, :length, :map, :max, :min, :minmax, :none?, :one?, :pack, :permutation,
          :pretty_print_cycle, :present?, :product, :reject, :repeated_combination, :repeated_permutation,
          :rassoc, :reverse, :reverse_each, :rindex, :rotate, :sample, :second, :second_to_last, :select,

--- a/lib/activeresource/test/cases/collection_test.rb
+++ b/lib/activeresource/test/cases/collection_test.rb
@@ -68,7 +68,7 @@ class ArrayMethodDelegate < ActiveSupport::TestCase
       :==, :[], :&, :*, :+, :-, :<=>, :all?, :any?, :as_json, :at, :assoc, :blank?, :bsearch, :bsearch_index,
       :collect, :combination, :compact, :count, :cycle, :deconstruct, :deep_dup, :dig, :difference, :drop,
       :drop_while, :each, :each_index, :empty?, :eql?, :excluding, :filter, :fifth, :find_index, :first,
-      :flatten, :forty_two, :fourth, :from, :hash, :include?, :including, :index, :inspect, :intersect?,
+      :flatten, :fourth, :from, :hash, :include?, :including, :index, :inspect, :intersect?,
       :intersection, :join, :last, :length, :map, :max, :min, :minmax, :none?, :one?, :pack, :permutation,
       :pretty_print_cycle, :present?, :product, :reject, :repeated_combination, :repeated_permutation,
       :rassoc, :reverse, :reverse_each, :rindex, :rotate, :sample, :second, :second_to_last, :select,

--- a/spec/active_cached_resource/caching_strategies/base_spec.rb
+++ b/spec/active_cached_resource/caching_strategies/base_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ActiveCachedResource::CachingStrategies::Base do
 
       prefix, digest = hashed_key.split(ActiveCachedResource::Constants::PREFIX_SEPARATOR)
       expect(prefix).to eq("prefix")
-      expect(digest).to eq(Digest::SHA256.hexdigest("mykey"))
+      expect(digest).to eq(Digest::MD5.hexdigest("mykey"))
     end
 
     it "handles keys with multiple dashes" do
@@ -42,7 +42,7 @@ RSpec.describe ActiveCachedResource::CachingStrategies::Base do
 
       prefix, digest = hashed_key.split(ActiveCachedResource::Constants::PREFIX_SEPARATOR)
       expect(prefix).to eq("prefix")
-      expect(digest).to eq(Digest::SHA256.hexdigest("part1#{ActiveCachedResource::Constants::PREFIX_SEPARATOR}part2"))
+      expect(digest).to eq(Digest::MD5.hexdigest("part1#{ActiveCachedResource::Constants::PREFIX_SEPARATOR}part2"))
     end
 
     context "Invalid keys" do


### PR DESCRIPTION
This pull request introduces enhancements to the `ActiveCachedResource` library, focusing on enabling virtual attributes to be persisted in cached collections, improving type annotations, and refining logging behavior. It also includes updates to tests and documentation to reflect these changes.

### Enhancements to Cached Collections:
* Introduced `persisted_attribute` and `virtual_persistable_attributes` in `ActiveCachedResource::Collection` to allow virtual attributes to be persisted in the cache. Added methods to track and serialize these attributes. (`lib/active_cached_resource/collection.rb`, [[1]](diffhunk://#diff-8c754e1b5c84b27db8b1c5809e4cf7d9e22e696c09c4dcad3967a67fa7d3567bL3-R24) [[2]](diffhunk://#diff-8c754e1b5c84b27db8b1c5809e4cf7d9e22e696c09c4dcad3967a67fa7d3567bL23-R68)
* Updated `json_to_object` and `object_to_json` methods to handle virtual persisted attributes when serializing/deserializing collections. (`lib/active_cached_resource/caching.rb`, [[1]](diffhunk://#diff-c7d7f0a1afabdb4728570e382d6677f5ea92af2c56b20edfeff42959b9ba38a3L245-R256) [[2]](diffhunk://#diff-c7d7f0a1afabdb4728570e382d6677f5ea92af2c56b20edfeff42959b9ba38a3L261-R277)

### Type Annotations and Documentation:
* Updated return types in `ClassMethods` to specify `ActiveCachedResource::Collection` and `ActiveCachedResource::Resource` instead of generic `Object` or `Array<Object>`. (`lib/active_cached_resource/caching.rb`, [lib/active_cached_resource/caching.rbL43-R46](diffhunk://#diff-c7d7f0a1afabdb4728570e382d6677f5ea92af2c56b20edfeff42959b9ba38a3L43-R46))

### Logging Refinements:
* Changed logging levels from `info` to `debug` for cache-related operations, such as clearing the cache and cache hits, to reduce verbosity in production logs. (`lib/active_cached_resource/caching.rb`, [[1]](diffhunk://#diff-c7d7f0a1afabdb4728570e382d6677f5ea92af2c56b20edfeff42959b9ba38a3L151-R152) [[2]](diffhunk://#diff-c7d7f0a1afabdb4728570e382d6677f5ea92af2c56b20edfeff42959b9ba38a3L169-R170)

### Test Suite Enhancements:
* Added tests for virtual persisted attributes, ensuring they are correctly persisted, retrieved, and updated from the cache. (`spec/active_cached_resource/collection_spec.rb`, [[1]](diffhunk://#diff-1eeb3b802ae40db0a90ad238953d6b511cc82ba77b3fe249391f0122975bb438L106-R130) [[2]](diffhunk://#diff-1eeb3b802ae40db0a90ad238953d6b511cc82ba77b3fe249391f0122975bb438R187-R225)
* Introduced a new test collection class (`TestCollectionWithPersistedAttributes`) to validate the behavior of virtual persisted attributes. (`spec/active_cached_resource/collection_spec.rb`, [[1]](diffhunk://#diff-1eeb3b802ae40db0a90ad238953d6b511cc82ba77b3fe249391f0122975bb438R3-R14) [[2]](diffhunk://#diff-1eeb3b802ae40db0a90ad238953d6b511cc82ba77b3fe249391f0122975bb438R26-R37)

### Miscellaneous:
* Updated the changelog to document the new feature for persisting virtual attributes and other recent changes. (`CHANGELOG.md`, [CHANGELOG.mdR1-R6](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6))
* Removed unused delegation methods (`:forty_two`, `:from`) from `ActiveResource::Collection` and updated related tests. (`lib/activeresource/lib/active_resource/collection.rb`, [[1]](diffhunk://#diff-1183aaa4c8a0d214703287c8e875a0211857f8acd3363a20d7d57663c8968c0eL12-R12); `lib/activeresource/test/cases/collection_test.rb`, [[2]](diffhunk://#diff-ba121d0ed442ebc07bedee375aafee219ae3216566cd4790bf0267894faf41c5L71-R71)