### PR TITLE
Fix specs and ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - ruby: "3.2"
           - ruby: "3.3"
-          - ruby: head
+          - ruby: "3.4"
     steps:
       - uses: actions/checkout@v4
       - name: Load dotenv into workflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+FROM debian:bullseye-slim AS base
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV ASDF_DIR=/root/.asdf
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    bash \
+    build-essential \
+    curl \
+    git \
+    libffi-dev \
+    libssl-dev \
+    perl \
+    libreadline-dev \
+    tzdata \
+    libyaml-dev \
+    zlib1g-dev
+
+RUN git clone https://github.com/asdf-vm/asdf.git /root/.asdf --branch v0.14.0 && \
+    . "$ASDF_DIR/asdf.sh" && \
+    asdf plugin add ruby
+
+# Ruby 3.2
+FROM base AS ruby-3.2
+RUN . "$ASDF_DIR/asdf.sh" && \
+    asdf install ruby $(asdf latest ruby 3.2) && \
+    asdf global ruby $(asdf latest ruby 3.2) && \
+    gem install bundler
+
+# Ruby 3.3
+FROM base AS ruby-3.3
+RUN . "$ASDF_DIR/asdf.sh" && \
+    asdf install ruby $(asdf latest ruby 3.3) && \
+    asdf global ruby $(asdf latest ruby 3.3) && \
+    gem install bundler
+
+# Ruby 3.4
+FROM base AS ruby-3.4
+RUN . "$ASDF_DIR/asdf.sh" && \
+    asdf install ruby $(asdf latest ruby 3.4) && \
+    asdf global ruby $(asdf latest ruby 3.4) && \
+    gem install bundler
+
+# Final Image with Application Code
+FROM base AS final
+
+# Copy and merge installed ASDF directory from ruby versions
+COPY --from=ruby-3.2 /root/.asdf /tmp/.asdf-3.2
+COPY --from=ruby-3.3 /root/.asdf /tmp/.asdf-3.3
+COPY --from=ruby-3.4 /root/.asdf /tmp/.asdf-3.4
+RUN cp -r /tmp/.asdf-3.2/* /root/.asdf/ && \
+    cp -r /tmp/.asdf-3.3/* /root/.asdf/ && \
+    cp -r /tmp/.asdf-3.4/* /root/.asdf/ && \
+    rm -rf /tmp/.asdf*
+
+WORKDIR /app
+
+COPY bin bin
+COPY lib lib
+COPY spec spec
+COPY scripts scripts
+COPY sorbet sorbet
+COPY .env .rubocop.yml .standard.yml active_cached_resource.gemspec Gemfile Rakefile .
+
+CMD ['. "$ASDF_DIR/asdf.sh"', "&&", "tail", "-f", "/dev/null"]

--- a/Rakefile
+++ b/Rakefile
@@ -8,21 +8,27 @@ if (Bundler.definition.groups - Bundler.settings[:without] + Bundler.settings[:w
   require "rspec/core/rake_task"
   require "rubocop/rake_task"
 
-  # ActiveCachedResource tests
-  RSpec::Core::RakeTask.new(:spec)
-  RuboCop::RakeTask.new(:rubocop)
+  RSpec::Core::RakeTask.new(:spec) do |r|
+    r.rspec_opts = ["--no-color"]
+    r.verbose = false
+  end
+
+  RuboCop::RakeTask.new(:rubocop) do |r|
+    r.options = ["--no-color", "--format", "simple"]
+    r.verbose = false
+  end
 
   # ActiveResource tests
   Rake::TestTask.new(:active_resource_test) do |t|
     t.libs = ["lib/activeresource/test"]
     t.pattern = "lib/activeresource/test/**/*_test.rb"
-    t.warning = true
-    t.verbose = true
+    t.warning = false
+    t.verbose = false
   end
 
   desc "Type check"
   task :tc do
-    sh "srb tc"
+    sh "bundle exec srb tc"
   end
 
   task default: [:tc, :rubocop, :spec, :active_resource_test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+---
+
+services:
+  app:
+    container_name: acr
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash scripts/run_tests.sh
+    volumes:
+      - .:/app

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,47 @@
+#!/usr/local/bin/bash
+
+set -e
+
+export BUNDLE_SILENCE_ROOT_WARNING=1
+export BUNDLE_IGNORE_MESSAGES=1
+
+. "$ASDF_DIR/asdf.sh"
+SPEC_RESULTS="coverage/spec_results"
+mkdir -p "$SPEC_RESULTS"
+
+# Ruby versions to test
+LINTER_RUBY_VERSION=$(asdf latest ruby 3.2)
+RUBY_VERSIONS=$(asdf list ruby)
+# Maximum number of concurrent processes
+MAX_PARALLEL=3
+CURRENT_PARALLEL=0
+
+run_rspec() {
+  local ruby_version="$1"
+
+  printf "\n********* Testing with Ruby $ruby_version *********\n\n"
+
+  bundle install --quiet --no-cache
+  # Run tests
+  bundle exec rake
+}
+
+# Iterate over Ruby versions
+for RUBY_VERSION in $RUBY_VERSIONS; do
+  (
+  asdf reshim ruby $RUBY_VERSION
+  asdf shell ruby $RUBY_VERSION
+
+  run_rspec "$RUBY_VERSION" "$RAILS_VERSION"
+  ) &
+
+  CURRENT_PARALLEL=$((CURRENT_PARALLEL + 1))
+  while [ $CURRENT_PARALLEL -ge $MAX_PARALLEL ]; do
+    sleep 1
+    CURRENT_PARALLEL=$(jobs -r | wc -l)
+  done
+done
+
+wait
+
+printf "\n********* DONE *********\n"

--- a/spec/active_cached_resource/caching_strategies/sql_cache_spec.rb
+++ b/spec/active_cached_resource/caching_strategies/sql_cache_spec.rb
@@ -1,25 +1,8 @@
-require "active_record"
-require "sqlite3"
-
 class CacheModel < ActiveRecord::Base
   self.table_name = "active_cached_resources"
 end
 
 RSpec.describe ActiveCachedResource::CachingStrategies::SQLCache do
-  before(:context) do
-    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-
-    ActiveRecord::Schema.define do
-      create_table :active_cached_resources, force: true do |t|
-        t.string :key, null: false
-        t.binary :value, null: false
-        t.datetime :expires_at, null: false
-
-        t.index [:key, :expires_at], unique: true, name: "index_active_cached_resources_on_key_and_expires_at"
-      end
-    end
-  end
-
   let(:constructor_args) { [CacheModel] }
 
   it_behaves_like "a caching strategy"

--- a/spec/active_cached_resource/model_spec.rb
+++ b/spec/active_cached_resource/model_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe ActiveCachedResource::Model do
       TestResource.setup_cached_resource!(
         cache_store: ActiveSupport::Cache::MemoryStore.new,
         cache_strategy: :active_support_cache,
-        ttl: 600
+        ttl: 600,
+        logger: Logger.new(IO::NULL)
       )
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "dotenv/load"
-
 require "simplecov"
 
 Dir.glob(File.join(__dir__, "support", "**", "*.rb")).each { |f| require_relative f }
@@ -12,8 +11,13 @@ SimpleCov.start do
   add_filter "/lib/active_resource/"
 end
 require "active_cached_resource"
+require "active_record"
+require "sqlite3"
+
+ActiveRecord::Schema.verbose = false
 
 RSpec.configure do |config|
+  include ActiveSupport::LoggerSilence
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
@@ -22,5 +26,21 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:suite) do
+    ActiveSupport::LoggerSilence.silence do
+      ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+
+      ActiveRecord::Schema.define do
+        create_table :active_cached_resources, force: true do |t|
+          t.string :key, null: false
+          t.binary :value, null: false
+          t.datetime :expires_at, null: false
+
+          t.index [:key, :expires_at], unique: true, name: "index_active_cached_resources_on_key_and_expires_at"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request introduces several significant changes to improve testing, streamline Docker setup, and enhance configuration management. The most important updates include adding support for Ruby 3.4, creating a new `Dockerfile` and `docker-compose.yml` for containerized builds and tests, refactoring Rake tasks for better output control, and centralizing ActiveRecord setup in the RSpec configuration.

### Ruby Version Updates:
* Updated `.github/workflows/test.yml` to replace `ruby: head` with `ruby: "3.4"` for CI testing.
* Added support for Ruby 3.4 in the newly created `Dockerfile`, alongside Ruby 3.2 and 3.3, using ASDF for version management.

### Docker and Testing Setup:
* Introduced a `Dockerfile` to build images for different Ruby versions and a final image with application code.
* Added a `docker-compose.yml` file to define services for the application and testing environment.
* Created a `scripts/run_tests.sh` script to run tests across multiple Ruby versions in parallel

### Rake Task Improvements:
* Refactored Rake tasks in `Rakefile` to suppress verbose output and add options for no-color output in RSpec and RuboCop.

### ActiveRecord Setup Consolidation:
* Moved ActiveRecord setup for in-memory SQLite to `spec/spec_helper.rb` under a `before(:suite)` hook, centralizing database initialization for tests.
* Removed redundant ActiveRecord setup from `spec/active_cached_resource/caching_strategies/sql_cache_spec.rb`.

### Logging and Configuration Enhancements:
* Added a `logger` option to `TestResource.setup_cached_resource!` in `spec/active_cached_resource/model_spec.rb` to suppress logging during tests.