### PR TITLE
0.2.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v46
         with:
           files: |
             **/*.{rb,ru,rake,gemspec}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           bundler-cache: true
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v46
         with:
           files: "lib/active_cached_resource/version.rb"
       - name: Bump Patch Version

--- a/lib/activeresource/lib/active_resource/associations.rb
+++ b/lib/activeresource/lib/active_resource/associations.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "pry-byebug" # IGNORE: This line is for debugging purposes and should be removed in production code.
 module ActiveResource::Associations
   module Builder
     autoload :Association, "activeresource/lib/active_resource/associations/builder/association"
@@ -148,7 +149,9 @@ module ActiveResource::Associations
       elsif attributes.include?(method_name)
         attributes[method_name]
       elsif !new_record?
-        instance_variable_set(ivar_name, reflection.klass.find(:all, params: { self.class.primary_key => self.id }))
+        # Association would be set on custom primary key if explicitly defined, otherwise use convention _id
+        assoc_key = self.class.custom_primary_key || "#{self.class.element_name}_id"
+        instance_variable_set(ivar_name, reflection.klass.find(:all, params: { assoc_key => self.id }))
       else
         instance_variable_set(ivar_name, reflection.klass.none)
       end

--- a/lib/activeresource/lib/active_resource/associations.rb
+++ b/lib/activeresource/lib/active_resource/associations.rb
@@ -2,10 +2,10 @@
 
 module ActiveResource::Associations
   module Builder
-    autoload :Association, "active_resource/associations/builder/association"
-    autoload :HasMany,     "active_resource/associations/builder/has_many"
-    autoload :HasOne,      "active_resource/associations/builder/has_one"
-    autoload :BelongsTo,   "active_resource/associations/builder/belongs_to"
+    autoload :Association, "activeresource/lib/active_resource/associations/builder/association"
+    autoload :HasMany,     "activeresource/lib/active_resource/associations/builder/has_many"
+    autoload :HasOne,      "activeresource/lib/active_resource/associations/builder/has_one"
+    autoload :BelongsTo,   "activeresource/lib/active_resource/associations/builder/belongs_to"
   end
 
 
@@ -148,9 +148,9 @@ module ActiveResource::Associations
       elsif attributes.include?(method_name)
         attributes[method_name]
       elsif !new_record?
-        instance_variable_set(ivar_name, reflection.klass.find(:all, params: { "#{self.class.element_name}_id": self.id }))
+        instance_variable_set(ivar_name, reflection.klass.find(:all, params: { self.class.primary_key => self.id }))
       else
-        instance_variable_set(ivar_name, reflection.klass.find(:all))
+        instance_variable_set(ivar_name, reflection.klass.none)
       end
     end
   end

--- a/lib/activeresource/lib/active_resource/associations/builder/association.rb
+++ b/lib/activeresource/lib/active_resource/associations/builder/association.rb
@@ -4,7 +4,7 @@ module ActiveResource::Associations::Builder
   class Association # :nodoc:
     # providing a Class-Variable, which will have a different store of subclasses
     class_attribute :valid_options
-    self.valid_options = [:class_name]
+    self.valid_options = [:class_name, :foreign_key]
 
     # would identify subclasses of association
     class_attribute :macro

--- a/lib/activeresource/lib/active_resource/base.rb
+++ b/lib/activeresource/lib/active_resource/base.rb
@@ -672,6 +672,10 @@ module ActiveResource
         end
       end
 
+      def none
+        collection_parser.none
+      end
+
       # An instance of ActiveResource::Connection that is the base \connection to the remote service.
       # The +refresh+ parameter toggles whether or not the \connection is refreshed at every request
       # or not (defaults to <tt>false</tt>).
@@ -716,6 +720,10 @@ module ActiveResource
       end
 
       attr_writer :primary_key
+
+      def custom_primary_key
+        @primary_key
+      end
 
       def primary_key
         if defined?(@primary_key)

--- a/lib/activeresource/lib/active_resource/base.rb
+++ b/lib/activeresource/lib/active_resource/base.rb
@@ -1226,6 +1226,10 @@ module ActiveResource
       load(attributes, false, persisted)
     end
 
+    def [](key)
+      public_send(key)
+    end
+
     # Returns a \clone of the resource that hasn't been assigned an +id+ yet and
     # is treated as a \new resource.
     #

--- a/lib/activeresource/lib/active_resource/collection.rb
+++ b/lib/activeresource/lib/active_resource/collection.rb
@@ -6,12 +6,12 @@ require "active_support/inflector"
 module ActiveResource # :nodoc:
   class Collection # :nodoc:
     include Enumerable
-    delegate :==, :[], :&, :*, :+, :-, :<=>, :all?, :any?, :as_json, :at, :assoc, :blank?, :bsearch, :bsearch_index,
-         :collect, :combination, :compact, :count, :cycle, :deconstruct, :deep_dup, :dig, :difference, :drop,
+    delegate :==, :[], :&, :*, :+, :-, :<=>, :<<, :all?, :any?, :as_json, :at, :assoc, :blank?, :bsearch, :bsearch_index,
+         :collect, :combination, :compact, :concat, :count, :cycle, :deconstruct, :deep_dup, :dig, :difference, :drop,
          :drop_while, :each, :each_index, :empty?, :eql?, :excluding, :filter, :fifth, :find_index, :first,
          :flatten, :fourth, :hash, :include?, :including, :index, :inspect, :intersect?,
          :intersection, :join, :last, :length, :map, :max, :min, :minmax, :none?, :one?, :pack, :permutation,
-         :pretty_print_cycle, :present?, :product, :reject, :repeated_combination, :repeated_permutation,
+         :pretty_print_cycle, :present?, :product, :push, :reject, :repeated_combination, :repeated_permutation,
          :rassoc, :reverse, :reverse_each, :rindex, :rotate, :sample, :second, :second_to_last, :select,
          :shelljoin, :shuffle, :size, :slice, :sort, :sum, :take, :take_while, :third, :third_to_last, :to,
          :to_a, :to_ary, :to_fs, :to_formatted_s, :to_h, :to_param, :to_query, :to_s, :to_sentence, :to_xml,

--- a/lib/activeresource/test/cases/base_test.rb
+++ b/lib/activeresource/test/cases/base_test.rb
@@ -1619,4 +1619,53 @@ class BaseTest < ActiveSupport::TestCase
   ensure
     ActiveResource::Base.include_format_in_path = true
   end
+
+  def test_custom_primary_key_reader_and_writer
+    klass = Class.new(ActiveResource::Base)
+    assert_nil klass.custom_primary_key
+
+    klass.primary_key = :uuid
+    assert_equal :uuid, klass.custom_primary_key
+
+    klass.primary_key = "custom_id"
+    assert_equal "custom_id", klass.custom_primary_key
+  end
+
+  def test_custom_primary_key_does_not_affect_default_primary_key
+    klass = Class.new(ActiveResource::Base)
+    assert_equal "id", klass.primary_key
+    assert_nil klass.custom_primary_key
+
+    klass.primary_key = :uuid
+    assert_equal :uuid, klass.primary_key
+    assert_equal :uuid, klass.custom_primary_key
+  end
+
+  def test_custom_primary_key_inheritance
+    parent = Class.new(ActiveResource::Base)
+    child = Class.new(parent)
+
+    parent.primary_key = :uuid
+    assert_equal :uuid, parent.custom_primary_key
+    assert_nil child.custom_primary_key
+
+    child.primary_key = :custom_id
+    assert_equal :custom_id, child.custom_primary_key
+    assert_equal :uuid, parent.custom_primary_key
+  end
+
+  def test_none_returns_empty_collection
+    none_result = Person.none
+    assert_kind_of ActiveResource::Collection, none_result
+    assert_empty none_result
+  end
+
+  def test_none_with_custom_collection_parser
+    custom_parser = Class.new(ActiveResource::Collection)
+    klass = Class.new(ActiveResource::Base)
+    klass.collection_parser = custom_parser
+    none_result = klass.none
+    assert_kind_of custom_parser, none_result
+    assert_empty none_result
+  end
 end


### PR DESCRIPTION
This pull request includes updates to workflows, enhancements to the `ActiveResource` library, and minor refactoring. Key changes include upgrading dependencies in GitHub Actions workflows, improving association handling, and adding new methods and delegated functionality to enhance usability.

### Workflow Updates:
* `.github/workflows/lint.yml` and `.github/workflows/release.yml`: Upgraded `tj-actions/changed-files` from version `v42` to `v46` for better compatibility and performance. [[1]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L15-R15) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L49-R49)

### Enhancements to `ActiveResource`:
* [`lib/activeresource/lib/active_resource/associations/builder/association.rb`](diffhunk://#diff-71c8e84854f96fe3d651a13f4c24399cfba0ef0176f1221775abc58b2dced511L7-R7): Added support for `:foreign_key` in `valid_options` to allow more flexibility in defining associations.
* [`lib/activeresource/lib/active_resource/base.rb`](diffhunk://#diff-d5267df8d7357cc469fb7a912b1b0ec28c81496c51a6f58269d53fae37925961R1229-R1232): Introduced a `[]` method to allow attribute access using hash-like syntax.
* [`lib/activeresource/lib/active_resource/collection.rb`](diffhunk://#diff-1183aaa4c8a0d214703287c8e875a0211857f8acd3363a20d7d57663c8968c0eL9-R14): Expanded delegated methods to include `<<`, `concat`, and `push`, improving the usability of `ActiveResource::Collection`.

### Refactoring:
* [`lib/activeresource/lib/active_resource/associations.rb`](diffhunk://#diff-609b736ac1c1c90650f997fdbb5ba977e3b80751fc66108b81e9a8ddc2ed143aL5-R8): Updated `autoload` paths to align with the directory structure and improved `defines_has_many_finder_method` by replacing `self.class.element_name` with `self.class.primary_key` and using `none` for empty results. [[1]](diffhunk://#diff-609b736ac1c1c90650f997fdbb5ba977e3b80751fc66108b81e9a8ddc2ed143aL5-R8) [[2]](diffhunk://#diff-609b736ac1c1c90650f997fdbb5ba977e3b80751fc66108b81e9a8ddc2ed143aL151-R153)